### PR TITLE
ci: run go mod tidy after renovate upgrades

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,11 @@
   "postUpdateOptions": [
     "gomodUpdateImportPaths"
   ],
+  "postUpgradeTasks": {
+    "commands": ["go mod tidy"],
+    "fileFilters": ["go.sum"],
+    "executionMode": "branch"
+  },
   "ignoreDeps": [
     "docker.io/bitnami/redis",
     "docker.io/bitnami/redis-sentinel",


### PR DESCRIPTION
## Summary

Adds `postUpgradeTasks` to run `go mod tidy` automatically after every Renovate dependency upgrade.

## Context

Renovate updates `go.mod` and downloads hashes for the modules it explicitly bumps, but does not run `go mod tidy`. This means transitive dependencies that receive an indirect version bump get a `go.mod` hash entry in `go.sum` but no `h1:` source archive hash — causing `go install` to fail at CI time with:

```
missing go.sum entry for module providing package go.uber.org/zap
    (imported by sigs.k8s.io/controller-runtime/tools/setup-envtest)
```

This was observed on the current `renovate/non-minor-deps` PR where bumping `setup-envtest v0.24.0 → v0.24.1` pulled in `go.uber.org/zap v1.27.1` as a new transitive, but only its `go.mod` hash (not its `h1:` source hash) was added to `go.sum`.

## Fix

`postUpgradeTasks` instructs Renovate to run `go mod tidy` on the branch after applying upgrades, which resolves and writes all missing `h1:` hashes into `go.sum` before the PR is opened.

- `executionMode: branch` — runs once per branch (not per package), correct for grouped PRs
- `fileFilters: ["go.sum"]` — allows Renovate to commit the updated `go.sum`