### PR TITLE
ci: use gomodTidy postUpdateOption to fix incomplete go.sum

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,13 +11,9 @@
   "prConcurrentLimit": 10,
   "semanticCommits": "enabled",
   "postUpdateOptions": [
-    "gomodUpdateImportPaths"
+    "gomodUpdateImportPaths",
+    "gomodTidy"
   ],
-  "postUpgradeTasks": {
-    "commands": ["go mod tidy"],
-    "fileFilters": ["go.sum"],
-    "executionMode": "branch"
-  },
   "ignoreDeps": [
     "docker.io/bitnami/redis",
     "docker.io/bitnami/redis-sentinel",


### PR DESCRIPTION
## Summary

Replaces the `postUpgradeTasks` approach (from #204) with the correct built-in Renovate option: `"gomodTidy"` in `postUpdateOptions`.

## Why the previous fix did not work

`postUpgradeTasks` requires `allowedPostUpgradeCommands` to be whitelisted in the **Mend Renovate hosted app server config** — a platform-level security gate that cannot be configured per repo. No other repo in the `sap-cs-devops` family uses it, confirming `go mod tidy` is not on the allowlist. The command never ran; Renovate silently ignored the task.

## The correct fix

`"gomodTidy"` is a **first-class built-in** `postUpdateOptions` value (same array as the already-present `"gomodUpdateImportPaths"`). It instructs Renovate to run `go mod tidy` natively after every Go dependency update — no allowlist, no shell exec, no security gate.

This resolves the recurring `missing go.sum entry for module providing package go.uber.org/zap` failure caused by `setup-envtest v0.24.0 → v0.24.1` pulling in `go.uber.org/zap v1.27.1` as a new transitive without a complete `go.sum` entry.